### PR TITLE
[feat] entity 연관관계 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 
 	//OAuth2
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/magnet/global/auth/handler/LoginAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/magnet/global/auth/handler/LoginAuthenticationSuccessHandler.java
@@ -5,19 +5,30 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 
 import java.io.IOException;
 
+/**
+ * 로그인 인증 성공과 동시에 Redis에 로그인한 사용자의 refreshToken을 저장한다.
+ * */
 @Slf4j
 public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
     private static final Logger logger = LoggerFactory.getLogger(LoginAuthenticationSuccessHandler.class);
+
+//    @Autowired
+//    private RedisTemplate<String, Object> redisTemplate;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
         logger.info("로그인 인증 성공");
         //Authentication 객체에 사용자 정보를 얻은 후, HttpServletResponse로 출력 스트림을 생성하여 response를 전송
+
+        // Redis에 jwt를 저장
+
     }
 
 }

--- a/src/main/java/com/example/magnet/global/auth/handler/OAuth2MemberSuccessHandler.java
+++ b/src/main/java/com/example/magnet/global/auth/handler/OAuth2MemberSuccessHandler.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -59,18 +58,18 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         String email = String.valueOf(oAuth2User.getAttributes().get("email")); // 이메일 추출
         List<String> authorities = authorityUtils.createRoles(email); // 추출한 이메일 기반의 권한 정보 생성
 
-//        saveMember(email); // Resource Owner의 이메일 주소를 DB에 저장
+        saveMember(email); // Resource Owner의 이메일 주소를 DB에 저장
         redirect(request, response, email, authorities);// Access Token과 Refresh Token을 생성 후 프론트에 전달
     }
 
-//    private void saveMember(String email){ // 권한이 생성된 이메일을 DB에 저장 > 조회용
-//        Member member = Member.builder().email(email).build();
-////        Member member = new Member(email);
-////        MemberService memberService = applicationContext.getBean(MemberService.class);
-//        memberService.createMember(member);
-//
-//        log.info("데이터베이스에 저장");
-//    }
+    private void saveMember(String email){ // 권한이 생성된 이메일을 DB에 저장 > 조회용
+        Member member = Member.builder().email(email).build();
+//        Member member = new Member(email);
+//        MemberService memberService = applicationContext.getBean(MemberService.class);
+        memberService.createMember(member);
+
+        log.info("데이터베이스에 저장");
+    }
 
     private void redirect(HttpServletRequest request, HttpServletResponse response, String username, List<String> authorities) throws IOException {
         String accessToken = delegateAccessToken(username, authorities);
@@ -115,7 +114,7 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
                 .newInstance()
                 .scheme("http")
                 .host("localhost")
-                .port(8080) // default
+//                .port(80) // default
                 .path("/login/oauth2/code/google") // /receive-token.html
                 .queryParams(queryParams)
                 .build()

--- a/src/main/java/com/example/magnet/global/auth/jwt/JwtTokenizer.java
+++ b/src/main/java/com/example/magnet/global/auth/jwt/JwtTokenizer.java
@@ -1,5 +1,6 @@
 package com.example.magnet.global.auth.jwt;
 
+//import com.example.magnet.global.auth.oauth.GeneratedToken;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -22,7 +23,6 @@ import java.util.Map;
 @Getter
 @Component
 public class JwtTokenizer {
-
 
     @Value("${jwt.key}")
     private String secretKey;
@@ -101,16 +101,20 @@ public class JwtTokenizer {
 
 //    // 최초 로그인 시 accessToken과 RefreshToken을 발급하는 부분 , oauth2 > MyAuthenticationSuccessHandler
 //    public GeneratedToken generateToken(String email, String role) {
-//        // refreshToken과 accessToken을 생성한다.
-//        String refreshToken = generateRefreshToken(subject, expiration, base64EncodedSecretKey);
-//        String accessToken = generateAccessToken(email, role);
+//        //accessToken을 생성한다.
+//        String accessToken = Jwts.builder()
+//                .setClaims(claims)
+//
+//
+//        // refreshToken을 생성한다.
+//        String refreshToken = generateRefreshToken(email, role);
+//
 //
 //        // 토큰을 Redis에 저장한다.
 //        tokenService.saveTokenInfo(email, refreshToken, accessToken);
 //        return new GeneratedToken(accessToken, refreshToken);
 //    }
 //
-//    //토큰에서 이메일 추출
-//    public String getUserEmail(String )
+//    /
 
 }

--- a/src/main/java/com/example/magnet/global/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/example/magnet/global/auth/jwt/JwtUtil.java
@@ -1,0 +1,117 @@
+//package com.example.magnet.global.auth.jwt;
+//
+//import com.example.magnet.global.auth.oauth.GeneratedToken;
+//import io.jsonwebtoken.Claims;
+//import io.jsonwebtoken.Jws;
+//import io.jsonwebtoken.Jwts;
+//import io.jsonwebtoken.SignatureAlgorithm;
+//import jakarta.annotation.PostConstruct;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.Base64;
+//import java.util.Date;
+//
+///**
+// * OAuth2.0용 access, refresh token 발급, 검증 클래스
+// * */
+//@Slf4j
+//@Service
+//@RequiredArgsConstructor
+//public class JwtUtil {
+//    private final JwtProperties jwtProperties;
+//    private final RefreshTokenService tokenService;
+//    private String secretKey;
+//
+////    @Value("${jwt.key}")
+////    private String secretKey;
+//
+//    @PostConstruct
+//    protected void init() {
+//        secretKey = Base64.getEncoder().encodeToString(jwtProperties.getSecret().getBytes());
+//    }
+//
+//    public GeneratedToken generateToken(String email, String role) {
+//        // refreshToken과 accessToken을 생성한다.
+//        String refreshToken = generateOAuth2RefreshToken(email, role);
+//        String accessToken = generateOAuth2AccessToken(email, role);
+//
+//        // 토큰을 Redis에 저장한다.
+//        tokenService.saveTokenInfo(email, refreshToken, accessToken);
+//        return new GeneratedToken(accessToken, refreshToken);
+//    }
+//
+//    public String generateOAuth2RefreshToken(String email, String role) {
+//        // 토큰의 유효 기간을 밀리초 단위로 설정.
+//        long refreshPeriod = 1000L * 60L * 60L * 24L * 14; // 2주
+//
+//        // 새로운 클레임 객체를 생성하고, 이메일과 역할(권한)을 셋팅
+//        Claims claims = Jwts.claims().setSubject(email);
+//        claims.put("role", role);
+//
+//        // 현재 시간과 날짜를 가져온다.
+//        Date now = new Date();
+//
+//        return Jwts.builder()
+//                // Payload를 구성하는 속성들을 정의한다.
+//                .setClaims(claims)
+//                // 발행일자를 넣는다.
+//                .setIssuedAt(now)
+//                // 토큰의 만료일시를 설정한다.
+//                .setExpiration(new Date(now.getTime() + refreshPeriod))
+//                // 지정된 서명 알고리즘과 비밀 키를 사용하여 토큰을 서명한다.
+//                .signWith(SignatureAlgorithm.HS256, secretKey)
+//                .compact();
+//    }
+//
+//
+//    public String generateOAuth2AccessToken(String email, String role) {
+//        long tokenPeriod = 1000L * 60L * 30L; // 30분
+//        Claims claims = Jwts.claims().setSubject(email);
+//        claims.put("role", role);
+//
+//        Date now = new Date();
+//        return
+//                Jwts.builder()
+//                        // Payload를 구성하는 속성들을 정의한다.
+//                        .setClaims(claims)
+//                        // 발행일자를 넣는다.
+//                        .setIssuedAt(now)
+//                        // 토큰의 만료일시를 설정한다.
+//                        .setExpiration(new Date(now.getTime() + tokenPeriod))
+//                        // 지정된 서명 알고리즘과 비밀 키를 사용하여 토큰을 서명한다.
+//                        .signWith(SignatureAlgorithm.HS256, secretKey)
+//                        .compact();
+//
+//    }
+//
+//    public boolean verifyToken(String token) {
+//        try {
+//            Jws<Claims> claims = Jwts.parser()
+//                    .setSigningKey(secretKey) // 비밀키를 설정하여 파싱한다.
+//                    .parseClaimsJws(token);  // 주어진 토큰을 파싱하여 Claims 객체를 얻는다.
+//            // 토큰의 만료 시간과 현재 시간비교
+//            return claims.getBody()
+//                    .getExpiration()
+//                    .after(new Date());  // 만료 시간이 현재 시간 이후인지 확인하여 유효성 검사 결과를 반환
+//        } catch (Exception e) {
+//            return false;
+//        }
+//    }
+//    // 토큰에서 Email을 추출한다.
+//    public String getUid(String token) {
+//        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+//    }
+//
+//    // 토큰에서 ROLE(권한)만 추출한다.
+//    public String getRole(String token) {
+//        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().get("role", String.class);
+//    }
+//
+//    // 토큰에서 memberId를 추출한다.
+////    public String getMemberId(String token){
+////        return Jwts.parserBuilder().setSigningKey(secretKey).
+////    }
+//}

--- a/src/main/java/com/example/magnet/global/auth/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/magnet/global/auth/oauth/CustomOAuth2UserService.java
@@ -1,77 +1,77 @@
-package com.example.magnet.global.auth.oauth;
-
-import com.example.magnet.member.entity.Member;
-import com.example.magnet.member.repository.MemberRepository;
-import com.example.magnet.member.service.MemberService;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.stereotype.Service;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-
-/**
- * OAuth 2.0 인증을 통해 사용자 정보를 가져오는 역할
- * */
-
-@Slf4j
-@Service
-@RequiredArgsConstructor
-@Transactional
-public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
-
-    private final MemberRepository memberRepository;
-
-    @Override
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        /**사용자 정보 생성 **/
-        // 기본 OAuth2UserService 객체 생성
-        OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
-
-        // OAuth2UserService를 사용하여 OAuth2User 정보를 가져온다.
-        OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
-
-        // 클라이언트 등록 ID(google, naver, kakao)와 사용자 이름 속성을 가져온다. - 어떤 플랫폼에서 oauth 인증했는지 id를 추출해서 구분
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        String userNameAttributeName = userRequest.getClientRegistration()
-                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
-
-
-        // OAuth2UserService를 사용하여 가져온 OAuth2User 정보로 OAuth2Attribute 객체를 만든다.
-        OAuth2Attribute oAuth2Attribute =
-                OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
-
-        // OAuth2Attribute의 속성값들을 Map으로 반환 받는다.
-        Map<String, Object> memberAttribute = oAuth2Attribute.convertToMap();
-
-        // 사용자 email(또는 id) 정보를 가져온다.
-        String email = (String) memberAttribute.get("email");
-        // 이메일로 가입된 회원인지 조회한다.
-        Optional<Member> findMember = memberRepository.findByEmail(email); // repo? reference: memberService.findByEmail(email);
-
-        if (findMember.isEmpty()) {
-            // 회원이 존재하지 않을경우, memberAttribute의 exist 값을 false로 넣어준다.
-            memberAttribute.put("exist", false);
-            // 회원의 권한(회원이 존재하지 않으므로 기본권한인 ROLE_USER를 넣어준다), 회원속성, 속성이름을 이용해 DefaultOAuth2User 객체를 생성해 반환한다.
-            return new DefaultOAuth2User(
-                    Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
-                    memberAttribute, "email");
-        }
-
-        // 회원이 존재할경우, memberAttribute의 exist 값을 true로 넣어준다.
-        memberAttribute.put("exist", true);
-        // 회원의 권한과, 회원속성, 속성이름을 이용해 DefaultOAuth2User 객체를 생성해 반환한다.
-        return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_".concat(findMember.get().getRoles().toString()))),
-                memberAttribute, "email");
-    }
-}
+//package com.example.magnet.global.auth.oauth;
+//
+//import com.example.magnet.member.entity.Member;
+//import com.example.magnet.member.repository.MemberRepository;
+//import com.example.magnet.member.service.MemberService;
+//import jakarta.transaction.Transactional;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.security.core.authority.SimpleGrantedAuthority;
+//import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+//import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+//import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+//import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+//import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+//import org.springframework.security.oauth2.core.user.OAuth2User;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.Collections;
+//import java.util.Map;
+//import java.util.Optional;
+//
+///**
+// * OAuth 2.0 인증을 통해 사용자 정보를 가져오는 역할
+// * */
+//
+//@Slf4j
+//@Service
+//@RequiredArgsConstructor
+//@Transactional
+//public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+//
+//    private final MemberRepository memberRepository;
+//
+//    @Override
+//    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+//        /**사용자 정보 생성 **/
+//        // 기본 OAuth2UserService 객체 생성
+//        OAuth2UserService<OAuth2UserRequest, OAuth2User> oAuth2UserService = new DefaultOAuth2UserService();
+//
+//        // OAuth2UserService를 사용하여 OAuth2User 정보를 가져온다.
+//        OAuth2User oAuth2User = oAuth2UserService.loadUser(userRequest);
+//
+//        // 클라이언트 등록 ID(google, naver, kakao)와 사용자 이름 속성을 가져온다. - 어떤 플랫폼에서 oauth 인증했는지 id를 추출해서 구분
+//        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+//        String userNameAttributeName = userRequest.getClientRegistration()
+//                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+//
+//
+//        // OAuth2UserService를 사용하여 가져온 OAuth2User 정보로 OAuth2Attribute 객체를 만든다.
+//        OAuth2Attribute oAuth2Attribute =
+//                OAuth2Attribute.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+//
+//        // OAuth2Attribute의 속성값들을 Map으로 반환 받는다.
+//        Map<String, Object> memberAttribute = oAuth2Attribute.convertToMap();
+//
+//        // 사용자 email(또는 id) 정보를 가져온다.
+//        String email = (String) memberAttribute.get("email");
+//        // 이메일로 가입된 회원인지 조회한다.
+//        Optional<Member> findMember = memberRepository.findByEmail(email); // repo? reference: memberService.findByEmail(email);
+//
+//        if (findMember.isEmpty()) {
+//            // 회원이 존재하지 않을경우, memberAttribute의 exist 값을 false로 넣어준다.
+//            memberAttribute.put("exist", false);
+//            // 회원의 권한(회원이 존재하지 않으므로 기본권한인 ROLE_USER를 넣어준다), 회원속성, 속성이름을 이용해 DefaultOAuth2User 객체를 생성해 반환한다.
+//            return new DefaultOAuth2User(
+//                    Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+//                    memberAttribute, "email");
+//        }
+//
+//        // 회원이 존재할경우, memberAttribute의 exist 값을 true로 넣어준다.
+//        memberAttribute.put("exist", true);
+//        // 회원의 권한과, 회원속성, 속성이름을 이용해 DefaultOAuth2User 객체를 생성해 반환한다.
+//        return new DefaultOAuth2User(
+//                Collections.singleton(new SimpleGrantedAuthority("ROLE_".concat(findMember.get().getRoles().toString()))),
+//                memberAttribute, "email");
+//    }
+//}

--- a/src/main/java/com/example/magnet/global/auth/oauth/GeneratedToken.java
+++ b/src/main/java/com/example/magnet/global/auth/oauth/GeneratedToken.java
@@ -1,15 +1,15 @@
-package com.example.magnet.global.auth.oauth;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
-
-@Getter
-@AllArgsConstructor
-@Builder @ToString
-public class GeneratedToken {
-
-    private String accessToken;
-    private String refreshToken;
-}
+//package com.example.magnet.global.auth.oauth;
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.ToString;
+//
+//@Getter
+//@AllArgsConstructor
+//@Builder @ToString
+//public class GeneratedToken {
+//
+//    private String accessToken;
+//    private String refreshToken;
+//}

--- a/src/main/java/com/example/magnet/global/auth/oauth/MyAuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/magnet/global/auth/oauth/MyAuthenticationSuccessHandler.java
@@ -1,6 +1,7 @@
 //package com.example.magnet.global.auth.oauth;
 //
 //import com.example.magnet.global.auth.jwt.JwtTokenizer;
+//import com.example.magnet.global.auth.jwt.JwtUtil;
 //import jakarta.servlet.ServletException;
 //import jakarta.servlet.http.HttpServletRequest;
 //import jakarta.servlet.http.HttpServletResponse;
@@ -25,7 +26,7 @@
 //@RequiredArgsConstructor
 //public class MyAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 //
-//    private final JwtTokenizer jwtUtil;
+//    private final JwtUtil jwtUtil;
 //
 //    @Override
 //    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {

--- a/src/main/java/com/example/magnet/global/auth/oauth/OAuth2Attribute.java
+++ b/src/main/java/com/example/magnet/global/auth/oauth/OAuth2Attribute.java
@@ -1,95 +1,95 @@
-package com.example.magnet.global.auth.oauth;
-
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
-
-import java.util.HashMap;
-import java.util.Map;
-
-/**
- * OAuth 인증을 통해 얻어온 사용자의 정보와 속성들(이메일, 프로필 사진, 닉네임 등)을 Map 형태로 반환받기 위해 사용하는 빌더 클래스
- * */
-
-@ToString
-@Builder(access = AccessLevel.PRIVATE) // Builder 메서드를 외부에서 사용하지 않으므로, Private 제어자로 지정
-@Getter
-public class OAuth2Attribute {
-    private Map<String, Object> attributes; // 사용자 속성 정보를 담는 Map
-    private String attributeKey; // 사용자 속성의 키 값
-    private String email; // 이메일 정보
-    private String name; // 이름 정보
-    private String picture; // 프로필 사진 정보
-    private String provider; // 제공자 정보
-
-    // 서비스에 따라 OAuth2Attribute 객체를 생성하는 메서드
-    static OAuth2Attribute of(String provider, String attributeKey,
-                              Map<String, Object> attributes) {
-        return switch (provider) {
-            case "google" -> ofGoogle(provider, attributeKey, attributes);
-//            case "kakao" -> ofKakao(provider, "email", attributes);
-            case "naver" -> ofNaver(provider, "id", attributes);
-            default -> throw new RuntimeException();
-        };
-    }
-
-    /*
-     *   Google 로그인일 경우 사용하는 메서드, 사용자 정보가 따로 Wrapping 되지 않고 제공되어,
-     *   바로 get() 메서드로 접근이 가능하다.
-     * */
-    private static OAuth2Attribute ofGoogle(String provider, String attributeKey,
-                                            Map<String, Object> attributes) {
-        return OAuth2Attribute.builder()
-                .email((String) attributes.get("email"))
-                .provider(provider)
-                .attributes(attributes)
-                .attributeKey(attributeKey)
-                .build();
-    }
-
-    /*
-     *   Kakao 로그인일 경우 사용하는 메서드, 필요한 사용자 정보가 kakaoAccount -> kakaoProfile 두번 감싸져 있어서,
-     *   두번 get() 메서드를 이용해 사용자 정보를 담고있는 Map을 꺼내야한다.
-     * */
-//    private static OAuth2Attribute ofKakao(String provider, String attributeKey,
-//                                           Map<String, Object> attributes) {
-//        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-//        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+//package com.example.magnet.global.auth.oauth;
 //
+//import lombok.AccessLevel;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.ToString;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//
+///**
+// * OAuth 인증을 통해 얻어온 사용자의 정보와 속성들(이메일, 프로필 사진, 닉네임 등)을 Map 형태로 반환받기 위해 사용하는 빌더 클래스
+// * */
+//
+//@ToString
+//@Builder(access = AccessLevel.PRIVATE) // Builder 메서드를 외부에서 사용하지 않으므로, Private 제어자로 지정
+//@Getter
+//public class OAuth2Attribute {
+//    private Map<String, Object> attributes; // 사용자 속성 정보를 담는 Map
+//    private String attributeKey; // 사용자 속성의 키 값
+//    private String email; // 이메일 정보
+//    private String name; // 이름 정보
+//    private String picture; // 프로필 사진 정보
+//    private String provider; // 제공자 정보
+//
+//    // 서비스에 따라 OAuth2Attribute 객체를 생성하는 메서드
+//    static OAuth2Attribute of(String provider, String attributeKey,
+//                              Map<String, Object> attributes) {
+//        return switch (provider) {
+//            case "google" -> ofGoogle(provider, attributeKey, attributes);
+////            case "kakao" -> ofKakao(provider, "email", attributes);
+//            case "naver" -> ofNaver(provider, "id", attributes);
+//            default -> throw new RuntimeException();
+//        };
+//    }
+//
+//    /*
+//     *   Google 로그인일 경우 사용하는 메서드, 사용자 정보가 따로 Wrapping 되지 않고 제공되어,
+//     *   바로 get() 메서드로 접근이 가능하다.
+//     * */
+//    private static OAuth2Attribute ofGoogle(String provider, String attributeKey,
+//                                            Map<String, Object> attributes) {
 //        return OAuth2Attribute.builder()
-//                .email((String) kakaoAccount.get("email"))
+//                .email((String) attributes.get("email"))
 //                .provider(provider)
-//                .attributes(kakaoAccount)
+//                .attributes(attributes)
 //                .attributeKey(attributeKey)
 //                .build();
 //    }
-
-    /*
-     *  Naver 로그인일 경우 사용하는 메서드, 필요한 사용자 정보가 response Map에 감싸져 있어서,
-     *  한번 get() 메서드를 이용해 사용자 정보를 담고있는 Map을 꺼내야한다.
-     * */
-    private static OAuth2Attribute ofNaver(String provider, String attributeKey,
-                                           Map<String, Object> attributes) {
-        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
-
-        return OAuth2Attribute.builder()
-                .email((String) response.get("email"))
-                .attributes(response)
-                .provider(provider)
-                .attributeKey(attributeKey)
-                .build();
-    }
-
-
-    // OAuth2User 객체에 넣어주기 위해서 Map으로 값들을 반환해준다.
-    Map<String, Object> convertToMap() {
-        Map<String, Object> map = new HashMap<>();
-        map.put("id", attributeKey);
-        map.put("key", attributeKey);
-        map.put("email", email);
-        map.put("provider", provider);
-
-        return map;
-    }
-}
+//
+//    /*
+//     *   Kakao 로그인일 경우 사용하는 메서드, 필요한 사용자 정보가 kakaoAccount -> kakaoProfile 두번 감싸져 있어서,
+//     *   두번 get() 메서드를 이용해 사용자 정보를 담고있는 Map을 꺼내야한다.
+//     * */
+////    private static OAuth2Attribute ofKakao(String provider, String attributeKey,
+////                                           Map<String, Object> attributes) {
+////        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+////        Map<String, Object> kakaoProfile = (Map<String, Object>) kakaoAccount.get("profile");
+////
+////        return OAuth2Attribute.builder()
+////                .email((String) kakaoAccount.get("email"))
+////                .provider(provider)
+////                .attributes(kakaoAccount)
+////                .attributeKey(attributeKey)
+////                .build();
+////    }
+//
+//    /*
+//     *  Naver 로그인일 경우 사용하는 메서드, 필요한 사용자 정보가 response Map에 감싸져 있어서,
+//     *  한번 get() 메서드를 이용해 사용자 정보를 담고있는 Map을 꺼내야한다.
+//     * */
+//    private static OAuth2Attribute ofNaver(String provider, String attributeKey,
+//                                           Map<String, Object> attributes) {
+//        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+//
+//        return OAuth2Attribute.builder()
+//                .email((String) response.get("email"))
+//                .attributes(response)
+//                .provider(provider)
+//                .attributeKey(attributeKey)
+//                .build();
+//    }
+//
+//
+//    // OAuth2User 객체에 넣어주기 위해서 Map으로 값들을 반환해준다.
+//    Map<String, Object> convertToMap() {
+//        Map<String, Object> map = new HashMap<>();
+//        map.put("id", attributeKey);
+//        map.put("key", attributeKey);
+//        map.put("email", email);
+//        map.put("provider", provider);
+//
+//        return map;
+//    }
+//}

--- a/src/main/java/com/example/magnet/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/magnet/global/config/SecurityConfig.java
@@ -31,7 +31,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import java.util.Arrays;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity(debug = true) // filter 호출 순서 반환
 @Slf4j
 public class SecurityConfig {
     private final JwtTokenizer jwtTokenizer;

--- a/src/main/java/com/example/magnet/member/entity/Member.java
+++ b/src/main/java/com/example/magnet/member/entity/Member.java
@@ -1,7 +1,9 @@
 package com.example.magnet.member.entity;
 
 import com.example.magnet.global.audit.TimeEntity;
+import com.example.magnet.mentee.entity.Mentee;
 import com.example.magnet.mentor.entity.Mentor;
+import com.example.magnet.mentoring.entity.Mentoring;
 import jakarta.annotation.Nonnull;
 import jakarta.persistence.*;
 import lombok.*;
@@ -51,6 +53,28 @@ public class Member extends TimeEntity implements Principal {
 
     @ElementCollection(fetch = FetchType.EAGER) // 테이블이 새로 생성됨
     private List<String> roles = new ArrayList<>();
+
+
+    /**
+     * Member entity는 모든 연관관계의 주인입니다. 등록, 수정이 가능합니다.
+     * */
+    //mentor
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MENTOR_ID")
+    private Mentor mentor;
+
+    //mentee
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MENTEE_ID")
+    private Mentee mentee;
+
+    //mentoring
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MENTORING_ID")
+    private Mentoring mentoring;
+
+
+
 
     //MemberDetails
     public void setMemberDetails(Member member){

--- a/src/main/java/com/example/magnet/mentee/entity/Mentee.java
+++ b/src/main/java/com/example/magnet/mentee/entity/Mentee.java
@@ -1,21 +1,35 @@
 package com.example.magnet.mentee.entity;
 
+import com.example.magnet.global.audit.TimeEntity;
+import com.example.magnet.member.entity.Member;
+import com.example.magnet.mentoring.entity.Mentoring;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
-public class Mentee {
+public class Mentee extends TimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "mentee_id")
+    @Column(name = "MENTEE_ID")
     private Long id;
 
     private String message;
     private String schedule;
 
+
+    //membr
+    @OneToMany(mappedBy = "mentee")
+    private List<Member> members = new ArrayList<>();
+
+    //mentorings
+    @OneToMany(mappedBy = "mentee")
+    private List<Mentoring> mentoringList = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/magnet/mentor/entity/Mentor.java
+++ b/src/main/java/com/example/magnet/mentor/entity/Mentor.java
@@ -1,24 +1,34 @@
 package com.example.magnet.mentor.entity;
 
+import com.example.magnet.global.audit.TimeEntity;
+import com.example.magnet.member.entity.Member;
+import com.example.magnet.mentoring.entity.Mentoring;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class Mentor {
+public class Mentor extends TimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "mentor_id")
+    @Column(name = "MENTOR_ID")
     private Long id;
 
     private String career;
     private String field;
     private String task;
 
-    // 생성일은 auditing
+    //member
+    @OneToMany(mappedBy = "mentor")
+    private List<Member> members = new ArrayList<>();
 
-
+    // mentoring
+    @OneToMany(mappedBy = "mentor")
+    private List<Mentoring> mentoringList = new ArrayList<>();
 }

--- a/src/main/java/com/example/magnet/mentoring/entity/Mentoring.java
+++ b/src/main/java/com/example/magnet/mentoring/entity/Mentoring.java
@@ -1,7 +1,13 @@
 package com.example.magnet.mentoring.entity;
 
+import com.example.magnet.member.entity.Member;
+import com.example.magnet.mentee.entity.Mentee;
+import com.example.magnet.mentor.entity.Mentor;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -20,5 +26,16 @@ public class Mentoring {
     private String period;
     private int participants;
 
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MENTOR_ID")
+    private Mentor mentor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MENTEE_ID")
+    private Mentee mentee;
+
+    @OneToMany(mappedBy = "mentoring")
+    private List<Member> members = new ArrayList<>();
 
 }


### PR DESCRIPTION
- member entity는 mentor, mentee, mentoring 엔티티에 대해 연관관계의 주인입니다. 
- 연관관계 주인 엔티티만 등록, 수정이 가능합니다. 
- 슬레이브 엔티티는 조회만 가능합니다. 
- 지연 로딩을 통해 프록시로 조회합니다. 
- oauth2.0 적용은 보류했습니다.