### PR TITLE
[feat]회원 탈퇴 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -58,8 +59,18 @@ dependencies {
 
 	//Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//Querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+clean {
+	delete file('src/main/generated')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,13 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// h2 for test
+	runtimeOnly 'com.h2database:h2'
+
+	//test 롬복 사용
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/magnet/MagnetApplication.java
+++ b/src/main/java/com/example/magnet/MagnetApplication.java
@@ -1,11 +1,15 @@
 package com.example.magnet;
 
+import com.example.magnet.global.auth.details.MemberDetailService;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetailsService;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -14,6 +18,7 @@ import java.util.UUID;
 @EnableJpaAuditing
 public class MagnetApplication {
 	// jwttokenprovider를 통해 주입 그 후 토큰 반환
+	Authentication authentication;
 
 
 	public static void main(String[] args) {
@@ -22,8 +27,16 @@ public class MagnetApplication {
 
 	@Bean
 	public AuditorAware<String> auditorProvider(){
-		return () -> Optional.of(UUID.randomUUID().toString());
 		// AuditorAware을 넘긴다. 해당 값들을 꺼내서 등록자, 수정자를 채워준다.
+		return () -> {
+			Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+			String currentUserId = null;
+
+			if (authentication != null && authentication.isAuthenticated()) {
+				currentUserId = (String)authentication.getCredentials();
+			}
+			return Optional.ofNullable(currentUserId);
+		};
 	}
 
 }

--- a/src/main/java/com/example/magnet/global/auth/details/MemberDetailService.java
+++ b/src/main/java/com/example/magnet/global/auth/details/MemberDetailService.java
@@ -45,7 +45,6 @@ public class MemberDetailService implements UserDetailsService {
 
     private final class MemberDetails extends Member implements UserDetails { // member 권한 정보 생성, 데이터베이스에서 조회한 회원 정보를 Spring Security의 User 정보로 변환하는 과정과 User의 권한 정보를 생성하는 과정을 캡슐화
           MemberDetails(Member member) {
-              logger.info("member 권한 정보 생성 - setter ");
             MemberBuilder builder = member.toBuilder();
             builder.id(member.getId());
             builder.email(member.getEmail());

--- a/src/main/java/com/example/magnet/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/magnet/global/config/SecurityConfig.java
@@ -59,7 +59,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/health", "member/signup", "auth/login", "/login/**").permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .requestMatchers("/mentor/**").hasRole("MENTOR")
+                        .requestMatchers("/mentor/create").hasRole("USER")
                         .requestMatchers("/mentee/**").hasRole("MENTEE")
                         .requestMatchers("/member/**").hasAnyRole("ADMIN","USER","MENTOR","MENTEE")
                         .requestMatchers("/member/extract").permitAll()

--- a/src/main/java/com/example/magnet/global/exception/ExceptionCode.java
+++ b/src/main/java/com/example/magnet/global/exception/ExceptionCode.java
@@ -9,9 +9,11 @@ public enum ExceptionCode {
     // member
     MEMBER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
 
-    MEMBER_EXISTS(409, "이미 사용자가 존재합니다.");
+    MEMBER_EXISTS(409, "이미 사용자가 존재합니다."),
 
     // mentor
+    MENTEE_CANT_REGISTER_MENTOR(400, "멘티는 멘토등록이 불가능합니다.");
+
 
     //mentee
 

--- a/src/main/java/com/example/magnet/member/controller/MemberController.java
+++ b/src/main/java/com/example/magnet/member/controller/MemberController.java
@@ -90,4 +90,10 @@ public class MemberController {
 
     // 회원 탈퇴
 
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> memberDelete(Authentication authentication){
+        Long memberId = (Long) authentication.getCredentials();
+        memberService.deleteMember(memberId);
+        return new ResponseEntity<>("회원 탈퇴가 이뤄졌습니다.", HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/magnet/member/dto/MemberPostDto.java
+++ b/src/main/java/com/example/magnet/member/dto/MemberPostDto.java
@@ -14,8 +14,7 @@ import lombok.NoArgsConstructor;
  * Nonnull은 jakarta로
  * */
 @Getter
-@Builder
-@AllArgsConstructor
+@NoArgsConstructor
 public class MemberPostDto {  // 회원 등록 dto
 
     @NotBlank
@@ -48,4 +47,14 @@ public class MemberPostDto {  // 회원 등록 dto
         private String street;
     }
 
+    @Builder
+    public MemberPostDto(String email, String username, String password, String nickName, String phone, String picture, AddressDto addressDto) {
+        this.email = email;
+        this.username = username;
+        this.password = password;
+        this.nickName = nickName;
+        this.phone = phone;
+        this.picture = picture;
+        this.addressDto = addressDto;
+    }
 }

--- a/src/main/java/com/example/magnet/member/entity/Member.java
+++ b/src/main/java/com/example/magnet/member/entity/Member.java
@@ -6,7 +6,11 @@ import com.example.magnet.mentor.entity.Mentor;
 import com.example.magnet.mentoring.entity.Mentoring;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import java.security.Principal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,6 +18,8 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class Member extends TimeEntity implements Principal {
 
     @Id
@@ -48,6 +54,10 @@ public class Member extends TimeEntity implements Principal {
     @CollectionTable(name = "Role", joinColumns = @JoinColumn(name = "MEMBER_ID"))
     private List<String> roles = new ArrayList<>();
 
+    // 회원 탈퇴 필드
+    private Boolean deleted = Boolean.FALSE; // 스케줄러 고도화
+    private LocalDateTime deletedAt;
+
     // 권한 부여 시 사용됨
     public void setRoles(List<String> roles) {
         this.roles = new ArrayList<>(roles); // 수정 가능한 새로운 리스트 생성
@@ -58,15 +68,15 @@ public class Member extends TimeEntity implements Principal {
      * Member 엔티티는 조회만 가능합니다.
      * */
     //mentor
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Mentor> mentorList = new ArrayList<>();
 
     //mentee
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Mentee> menteeList = new ArrayList<>();
 
     //mentoring
-    @OneToMany(mappedBy = "member")
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Mentoring> mentoringList = new ArrayList<>();
 
 

--- a/src/main/java/com/example/magnet/member/entity/Member.java
+++ b/src/main/java/com/example/magnet/member/entity/Member.java
@@ -21,14 +21,16 @@ public class Member extends TimeEntity implements Principal {
     @Column(name = "MEMBER_ID")
     private Long id;
 
-    private String username;
+    @Column(unique = true)
+    private String username; // unique key 설정하자
 
+    @Column(unique = true)
     private String nickName;
 
     @Column(nullable = false, updatable = false, unique = true)
     private String email; // id
 
-    @Column(nullable = false) // 암호화 되므로
+    @Column(nullable = false)
     private String password;
 
     private String phone;
@@ -42,8 +44,14 @@ public class Member extends TimeEntity implements Principal {
     @Column(length = 20)
     private MemberStatus memberStatus;
 
-    @ElementCollection(fetch = FetchType.EAGER) // 테이블이 새로 생성됨
+    @ElementCollection(fetch = FetchType.EAGER) // jpa에서 테이블을 새로 생성해서 관리.
+    @CollectionTable(name = "Role", joinColumns = @JoinColumn(name = "MEMBER_ID"))
     private List<String> roles = new ArrayList<>();
+
+    // 권한 부여 시 사용됨
+    public void setRoles(List<String> roles) {
+        this.roles = new ArrayList<>(roles); // 수정 가능한 새로운 리스트 생성
+    }
 
 
     /**
@@ -109,4 +117,16 @@ public class Member extends TimeEntity implements Principal {
         this.menteeList = menteeList;
         this.mentoringList = mentoringList;
     }
+
+//    @Override
+//    public boolean equals(Object o){
+//        if(this == o) return true;
+//        if(o == null || getClass() != o.getClass()) return false;
+//        Role member = (Member) o;
+//        return
+//    }
+//    @Override
+//    public int hashCode() {
+//        return Objects.hash(memberId, money);
+//    }
 }

--- a/src/main/java/com/example/magnet/member/entity/Role.java
+++ b/src/main/java/com/example/magnet/member/entity/Role.java
@@ -1,0 +1,21 @@
+package com.example.magnet.member.entity;
+
+import jakarta.persistence.Entity;
+
+@Entity
+public enum Role {
+    ROLE_USER("ROLE_USER"),
+    ROLE_MENTOR("ROLE_MENTOR"),
+    ROLE_MENTEE("ROLE_MENTEE"),
+    ROLE_ADMIN("ROLE_ADMIN");
+
+    String role;
+
+    Role(String role) {
+        this.role = role;
+    }
+
+    public String value() {
+        return role;
+    }
+}

--- a/src/main/java/com/example/magnet/member/entity/Role.java
+++ b/src/main/java/com/example/magnet/member/entity/Role.java
@@ -1,21 +1,21 @@
-package com.example.magnet.member.entity;
-
-import jakarta.persistence.Entity;
-
-@Entity
-public enum Role {
-    ROLE_USER("ROLE_USER"),
-    ROLE_MENTOR("ROLE_MENTOR"),
-    ROLE_MENTEE("ROLE_MENTEE"),
-    ROLE_ADMIN("ROLE_ADMIN");
-
-    String role;
-
-    Role(String role) {
-        this.role = role;
-    }
-
-    public String value() {
-        return role;
-    }
-}
+//package com.example.magnet.member.entity;
+//
+//import jakarta.persistence.Entity;
+//
+//@Entity
+//public enum Role {
+//    ROLE_USER("ROLE_USER"),
+//    ROLE_MENTOR("ROLE_MENTOR"),
+//    ROLE_MENTEE("ROLE_MENTEE"),
+//    ROLE_ADMIN("ROLE_ADMIN");
+//
+//    String role;
+//
+//    Role(String role) {
+//        this.role = role;
+//    }
+//
+//    public String value() {
+//        return role;
+//    }
+//}

--- a/src/main/java/com/example/magnet/member/mapper/MemberMapper.java
+++ b/src/main/java/com/example/magnet/member/mapper/MemberMapper.java
@@ -19,7 +19,6 @@ import static java.util.Arrays.stream;
 
 @Component
 @RequiredArgsConstructor
-
 public class MemberMapper {
 
     // post

--- a/src/main/java/com/example/magnet/member/service/MemberService.java
+++ b/src/main/java/com/example/magnet/member/service/MemberService.java
@@ -103,6 +103,16 @@ public class MemberService {
     }
 
 
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                        .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+        member.getMentorList().clear();
+        member.getMenteeList().clear();
+        member.getMentoringList().clear();
+        memberRepository.delete(member);
+
+    }
+
 
     // jwt의 memberId와 생성자가 같은지 판단하는 함수
 

--- a/src/main/java/com/example/magnet/mentor/controller/MentorController.java
+++ b/src/main/java/com/example/magnet/mentor/controller/MentorController.java
@@ -1,0 +1,55 @@
+package com.example.magnet.mentor.controller;
+
+import com.example.magnet.global.exception.BusinessLogicException;
+import com.example.magnet.global.exception.ExceptionCode;
+import com.example.magnet.mentor.dto.MentorPostDto;
+import com.example.magnet.mentor.entity.Mentor;
+import com.example.magnet.mentor.mapper.MentorMapper;
+import com.example.magnet.mentor.service.MentorService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/mentor")
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class MentorController {
+    private final MentorService mentorService;
+    private final MentorMapper mapper;
+
+    // 멘토 등록
+    @PostMapping("/create")
+    public ResponseEntity<?> register(@Valid @RequestBody MentorPostDto mentorPostDto, Authentication authentication){
+        Long memberId = (Long) authentication.getCredentials();
+        List<String> roles = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+
+        // 멘티 권한이 있다면 멘토로 등록할 수 없다.
+        if(roles.contains("MENTEE")){
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new BusinessLogicException(ExceptionCode.MENTEE_CANT_REGISTER_MENTOR));
+        }else{
+            Mentor mentor = mapper.MentorPostDtoToMentor(mentorPostDto);
+            mentorService.createMentor(memberId, mentor);
+        }
+
+        return new ResponseEntity<>("멘토 등록이 완료되었습니다.", HttpStatus.CREATED);
+
+    }
+
+    // 멘토 조회
+}

--- a/src/main/java/com/example/magnet/mentor/dto/MentorPostDto.java
+++ b/src/main/java/com/example/magnet/mentor/dto/MentorPostDto.java
@@ -1,0 +1,50 @@
+package com.example.magnet.mentor.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MentorPostDto {
+
+    @NotBlank
+    private String mentorName;
+
+    @NotBlank
+    private String field; // 직무분야
+
+    @NotBlank
+    private String career; // 경력
+
+    @NotBlank
+    private String task; // 현직 - 기업정보
+
+    @NotBlank
+    private String email; // 연락 이메일
+
+    @NotBlank
+    private String phone; // 연락처
+
+    @NotBlank
+    private String aboutMe;// 자기소개
+
+    @NotBlank
+    private String github; // github 링크
+
+
+    @Builder(toBuilder = true)
+    public MentorPostDto(String mentorName, String field, String career, String task, String email, String phone, String aboutMe, String github) {
+
+        this.mentorName = mentorName;
+        this.field = field;
+        this.career = career;
+        this.task = task;
+        this.email = email;
+        this.phone = phone;
+        this.aboutMe = aboutMe;
+        this.github = github;
+    }
+}

--- a/src/main/java/com/example/magnet/mentor/entity/Mentor.java
+++ b/src/main/java/com/example/magnet/mentor/entity/Mentor.java
@@ -38,7 +38,7 @@ public class Mentor extends TimeEntity {
 
 
     // mentoring, mentor
-    @OneToMany(mappedBy = "mentor")
+    @OneToMany(mappedBy = "mentor", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Mentoring> mentoringList = new ArrayList<>();
 
     @Builder(toBuilder = true)

--- a/src/main/java/com/example/magnet/mentor/entity/Mentor.java
+++ b/src/main/java/com/example/magnet/mentor/entity/Mentor.java
@@ -18,9 +18,17 @@ public class Mentor extends TimeEntity {
     @Column(name = "MENTOR_ID")
     private Long id;
 
-    private String career;
-    private String field;
-    private String task;
+    private String mentorName;
+
+    private String career; // 경력
+    private String field;  // 직무분야
+    private String task; // 현직- 기업정보
+    private String email; // 연락 이메일
+    private String phone; // 연락처
+    private String aboutMe;// 자기소개
+    private String github; // github 링크
+
+    // 계좌관련 정보 추가 가능
 
 
     //member, mentor
@@ -34,11 +42,16 @@ public class Mentor extends TimeEntity {
     private List<Mentoring> mentoringList = new ArrayList<>();
 
     @Builder(toBuilder = true)
-    public Mentor(Long id, String career, String field, String task, Member member, List<Mentoring> mentoringList) {
+    public Mentor(Long id, String mentorName, String career, String field, String task, String email, String phone, String aboutMe, String github, Member member, List<Mentoring> mentoringList) {
         this.id = id;
+        this.mentorName = mentorName;
         this.career = career;
         this.field = field;
         this.task = task;
+        this.email = email;
+        this.phone = phone;
+        this.aboutMe = aboutMe;
+        this.github = github;
         this.member = member;
         this.mentoringList = mentoringList;
     }

--- a/src/main/java/com/example/magnet/mentor/mapper/MentorMapper.java
+++ b/src/main/java/com/example/magnet/mentor/mapper/MentorMapper.java
@@ -1,0 +1,32 @@
+package com.example.magnet.mentor.mapper;
+
+import com.example.magnet.member.repository.MemberRepository;
+import com.example.magnet.mentor.dto.MentorPostDto;
+import com.example.magnet.mentor.entity.Mentor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MentorMapper {
+
+    //post
+    public Mentor MentorPostDtoToMentor(MentorPostDto mentorPostDto){
+        if(mentorPostDto == null){
+            return null;
+        }
+        Mentor mentor = Mentor.builder()
+                .mentorName(mentorPostDto.getMentorName())
+                .field(mentorPostDto.getField())
+                .phone(mentorPostDto.getPhone())
+                .task(mentorPostDto.getTask())
+                .email(mentorPostDto.getEmail())
+                .github(mentorPostDto.getGithub())
+                .career(mentorPostDto.getCareer())
+                .aboutMe(mentorPostDto.getAboutMe())
+                .build();
+
+        return mentor;
+
+    }
+}

--- a/src/main/java/com/example/magnet/mentor/repository/MentorRepository.java
+++ b/src/main/java/com/example/magnet/mentor/repository/MentorRepository.java
@@ -1,0 +1,8 @@
+package com.example.magnet.mentor.repository;
+
+import com.example.magnet.mentor.entity.Mentor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentorRepository extends JpaRepository<Mentor, Long> {
+
+}

--- a/src/main/java/com/example/magnet/mentor/service/MentorService.java
+++ b/src/main/java/com/example/magnet/mentor/service/MentorService.java
@@ -1,0 +1,60 @@
+package com.example.magnet.mentor.service;
+
+import com.example.magnet.global.auth.utils.CustomAuthorityUtils;
+import com.example.magnet.global.exception.BusinessLogicException;
+import com.example.magnet.global.exception.ExceptionCode;
+import com.example.magnet.member.entity.Member;
+import com.example.magnet.member.repository.MemberRepository;
+import com.example.magnet.mentor.entity.Mentor;
+import com.example.magnet.mentor.repository.MentorRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Service
+@Valid
+@RequiredArgsConstructor
+@Transactional
+public class MentorService {
+    private final MentorRepository mentorRepository;
+    private final MemberRepository memberRepository;
+    private final CustomAuthorityUtils customAuthorityUtils;
+
+    public void createMentor(Long memberId, Mentor mentor) {
+        // memberId로 멤버와 멘토 연관관계 생성
+        Member findMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+
+        // 연관관계 설정
+        Mentor.MentorBuilder saveMentor = mentor.toBuilder();
+        saveMentor.member(findMember);
+
+        // DB에 MENTOR 권한 부여 후 반영 - member.getRoles > add("MENTOR")
+//        List<String> updatedRoles = new ArrayList<>(findMember.getRoles()); // 수정 가능한 새로운 리스트 생성
+        List<String> updatedRoles = findMember.getRoles();
+        updatedRoles.add("MENTOR");
+        findMember.setRoles(updatedRoles);
+        memberRepository.save(findMember); // 기존의 컬럼에서 값을 조회하고 수정하지 않았다.
+
+        mentorRepository.save(saveMentor.build());
+
+        // 현재 스레드의 Authentication 업데이트
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Collection<? extends GrantedAuthority> authorities = customAuthorityUtils.createAuthorities(findMember.getRoles());
+        Authentication updatedAuthentication = new UsernamePasswordAuthenticationToken(authentication.getPrincipal(), authentication.getCredentials(), authorities);
+        SecurityContextHolder.getContext().setAuthentication(updatedAuthentication);
+
+    }
+
+
+
+}

--- a/src/test/java/com/example/magnet/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/magnet/member/service/MemberServiceTest.java
@@ -145,6 +145,23 @@ public class MemberServiceTest {
         assertEquals(existingMember, result);
     }
 
+    @Test
+    @DisplayName("회원 탈퇴 테스트")
+    void deleteMember(){
+        // 삭제 후 db 조회 시 찾을 수 없다는 예외를 발생하면 통과
+        Member existingMember = Member.builder()
+                .id(1L)
+                .username("testUser")
+                .nickName("OldNickName")
+                .build();
+
+        memberRepository.save(existingMember);
+
+        assertThrows(BusinessLogicException.class, () ->{
+            memberService.deleteMember(1L);
+        });
+    }
+
 
 
 

--- a/src/test/java/com/example/magnet/mentor/service/MentorServiceTest.java
+++ b/src/test/java/com/example/magnet/mentor/service/MentorServiceTest.java
@@ -1,0 +1,91 @@
+package com.example.magnet.mentor.service;
+
+import com.example.magnet.global.auth.utils.CustomAuthorityUtils;
+import com.example.magnet.member.entity.Member;
+import com.example.magnet.member.repository.MemberRepository;
+import com.example.magnet.mentor.entity.Mentor;
+import com.example.magnet.mentor.repository.MentorRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+class MentorServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MentorRepository mentorRepository;
+
+    @Mock
+    private CustomAuthorityUtils customAuthorityUtils;
+
+    @InjectMocks
+    private MentorService mentorService;
+
+    private Member member;
+
+    private Mentor mentor;
+
+    @BeforeEach
+    public void setUp(){
+        member = Member.builder()
+                .id(1L)
+                .roles(Arrays.asList("ROLE_USER"))
+                .build();
+
+        mentor = Mentor.builder()
+                .id(1L)
+                .member(member)
+                .build();
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken("user", "password", List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    @DisplayName("멘토등록 테스트")
+    public void create_Mentor(){
+        // given
+        Long memberId = 1L;
+
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+
+        List<GrantedAuthority> expectedAuthorities = List.of(
+                new SimpleGrantedAuthority("ROLE_USER"),
+                new SimpleGrantedAuthority("ROLE_MENTOR"));
+        when(customAuthorityUtils.createAuthorities(eq(List.of("USER", "MENTOR")))).thenReturn(expectedAuthorities);
+
+        // when
+        mentorService.createMentor(memberId, mentor);
+
+        // then
+        verify(memberRepository).save(member);
+        verify(mentorRepository).save(any());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        List<String> updatedRoles = member.getRoles(); // 수정된 roles 확인
+        assertThat(updatedRoles).contains("ROLE_MENTOR");
+        assertThat(authentication.getAuthorities()).isEqualTo(expectedAuthorities);
+    }
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,36 @@
+spring:
+  profiles:
+    active: test
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/magnet
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+      # show_sql: true
+        format_sql: true
+        use_sql_comments: true
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${CLIENT_ID}
+            client-secret: ${CLIENT_SECRET}
+            scope:
+              - profile
+              - email
+logging.level:
+  org.hibernate.SQL: debug
+
+jwt:
+  key: ${JWT_SECRET_KEY}
+  access-token-expiration-minutes: 60
+  refresh-token-expiration-minutes: 600
+mail:
+  address:
+    admin: admin@gmail.com


### PR DESCRIPTION
1. auditing 설정 추가 - 추후 mentoring에 적용 예정 
3. test code h2 설정 
4. 회원 탈퇴 구현 
- @sql, @where 추가 후 soft delete 적용 
- 영속성 전이와 고아 객체 방지를 위해, cascade = CascadeType.ALL, orphanRemoval = true적용 (member(mentor, mentee, mentoring), mentor(mentoring)에 적용)