### PR TITLE
[hotfix]mentoring 단건조회 dto 수정

### DIFF
--- a/src/main/java/com/example/magnet/mentoring/mapper/MentoringMapper.java
+++ b/src/main/java/com/example/magnet/mentoring/mapper/MentoringMapper.java
@@ -42,7 +42,7 @@ public class MentoringMapper {
                 .mentorId(mentoring.getMentor().getId())
                 .career(mentoring.getMentor().getCareer())
                 .field(mentoring.getMentor().getField())
-                .task(mentoring.getMentor().getField())
+                .task(mentoring.getMentor().getTask())
                 .email(mentoring.getMentor().getEmail())
                 .phone(mentoring.getMentor().getPhone())
                 .aboutMe(mentoring.getMentor().getAboutMe())


### PR DESCRIPTION
- mentoring mapper의 filed 반환값 수정 
- mentoring의 category와 mentor의 field 필드 추가적으로 일원화 필요 > 역할의 충돌 발생
