### PR TITLE
[refactor/test]member단건조회 dto 변경지점 refactor, 테스트코드 수정

### DIFF
--- a/src/main/java/com/example/magnet/member/controller/MemberController.java
+++ b/src/main/java/com/example/magnet/member/controller/MemberController.java
@@ -80,9 +80,8 @@ public class MemberController {
     @GetMapping("/get")
     public ResponseEntity<MemberResponseDto> getMember(Authentication authentication){
         Long memberId = (Long) authentication.getCredentials();
-        Member result = memberService.findMyInfo(memberId);
 
-        return new ResponseEntity<>(mapper.memberToResponseDto(result), HttpStatus.OK);
+        return new ResponseEntity<>(memberService.findMyInfo(memberId), HttpStatus.OK);
     }
 
 

--- a/src/main/java/com/example/magnet/member/service/MemberService.java
+++ b/src/main/java/com/example/magnet/member/service/MemberService.java
@@ -39,6 +39,15 @@ public class MemberService {
     private final MemberMapper mapper;
 
     /**
+     *  다른 계층에서 member의 엔티티를 호출하기 위해 사용
+     * **/
+    public Member findMemberById(Long memberId){
+        Member findMember = memberRepository.findById(memberId).orElseThrow(() ->
+                new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+        return findMember;
+    }
+
+    /**
      *  회원가입
      * - 이메일 기반으로 회원이 db에 존재하는지 판단 후 spring security의 createRoles를 통해 역할 생성
      * */
@@ -103,10 +112,10 @@ public class MemberService {
 
 
     @Transactional(readOnly = true)
-    public Member findMyInfo(Long memberId) {
+    public MemberResponseDto findMyInfo(Long memberId) {
         Member findMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
-        return findMember;
+        return mapper.memberToResponseDto(findMember);
     }
 
 

--- a/src/main/java/com/example/magnet/payment/service/PaymentService.java
+++ b/src/main/java/com/example/magnet/payment/service/PaymentService.java
@@ -4,6 +4,7 @@ import com.example.magnet.global.config.TossPaymentConfig;
 import com.example.magnet.global.exception.BusinessLogicException;
 import com.example.magnet.global.exception.ExceptionCode;
 import com.example.magnet.member.entity.Member;
+import com.example.magnet.member.repository.MemberRepository;
 import com.example.magnet.member.service.MemberService;
 import com.example.magnet.payment.dto.PaymentSuccessDto;
 import com.example.magnet.payment.entity.Payment;
@@ -39,7 +40,7 @@ public class PaymentService {
      * 사용자의 존재 확인 후 검증 로직 진행. 그 후 해당 결제 객체를 DB에 저장
      * */
     public Payment requestTossPayment(Payment payment, Long memberId){
-        Member member = memberService.findMyInfo(memberId);
+        Member member = memberService.findMemberById(memberId);
         if(payment.getAmount() < 1000){ // 1000원 미만이면 오류
             throw new BusinessLogicException(ExceptionCode.INVALID_PAYMENT_AMOUNT);
         }

--- a/src/test/java/com/example/magnet/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/magnet/member/service/MemberServiceTest.java
@@ -3,8 +3,10 @@ package com.example.magnet.member.service;
 import com.example.magnet.global.auth.utils.CustomAuthorityUtils;
 import com.example.magnet.global.exception.BusinessLogicException;
 import com.example.magnet.global.helper.event.MemberRegistrationApplicationEvent;
+import com.example.magnet.member.dto.MemberResponseDto;
 import com.example.magnet.member.entity.Address;
 import com.example.magnet.member.entity.Member;
+import com.example.magnet.member.mapper.MemberMapper;
 import com.example.magnet.member.repository.MemberRepository;
 import com.example.magnet.mentee.entity.Mentee;
 import com.example.magnet.mentee.repository.MenteeRepository;
@@ -33,8 +35,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
 @Transactional
+@ExtendWith(MockitoExtension.class)
 public class MemberServiceTest {
 
     @Mock
@@ -50,6 +52,9 @@ public class MemberServiceTest {
     PasswordEncoder passwordEncoder;
 
     @Mock
+    MemberMapper mapper;
+
+    @Mock
     CustomAuthorityUtils authorityUtils;
 
     @Mock
@@ -57,16 +62,6 @@ public class MemberServiceTest {
 
     @InjectMocks
     MemberService memberService;
-
-    @Mock
-    Member member;
-
-    @Mock
-    Mentor mentor;
-    @Mock
-    Mentoring mentoring;
-    @Mock
-    Mentee mentee;
 
 
 
@@ -148,25 +143,23 @@ public class MemberServiceTest {
         Member existingMember = Member.builder()
                 .id(1L)
                 .username("testUser")
-                .nickName("OldNickName")
-                .phone("O10-0000-0000")
-                .picture("domain-of-s3")
-                .memberStatus(Member.MemberStatus.MEMBER_ACTIVE)
-                .address(Address.builder().city("testCity").street("testStreet").build())
                 .roles(roles)
-                .menteeList(null)
-                .mentoringList(null)
-                .mentorList(null)
                 .build();
 
+        MemberResponseDto memberResponseDto = MemberResponseDto.builder()
+                .id(1L)
+                .username("testUser")
+                .roles(roles)
+                .build();
 
         // when
-        when(memberRepository.findById(1L)).thenReturn(Optional.ofNullable(existingMember));
+        when(mapper.memberToResponseDto(existingMember)).thenReturn(memberResponseDto);
 
-        // then
-        Member result = memberService.findMyInfo(1L);
+        MemberResponseDto result = mapper.memberToResponseDto(existingMember);
 
-        assertEquals(existingMember, result);
+        assertEquals(memberResponseDto.getId(), result.getId());
+        assertEquals(memberResponseDto.getUsername(), result.getUsername());
+        assertEquals(memberResponseDto.getRoles(), result.getRoles());
     }
 
     @Test


### PR DESCRIPTION
- member 단건조회 api에서 service계층에서 member 엔티티를 반환하던 기존 코드를 dto를 반환하도록 수정했습니다. 
- 관련 testcode를 수정했습니다. 
- paymentService에서 해당 member 단건조회 api를 이용해서 member엔티티를 반환하던 것을 추가적인 api생성으로 변경했습니다. 
- paymentService에서는 memberSerivce계층에만 접근하도록 수정했습니다. 