### PR TITLE
[refactor]ResponseEntity builder 패턴 적용

### DIFF
--- a/src/main/java/com/example/magnet/member/controller/MemberController.java
+++ b/src/main/java/com/example/magnet/member/controller/MemberController.java
@@ -53,7 +53,9 @@ public class MemberController {
     @ApiResponse(responseCode = "200", description = "정상적으로 가입되었습니다.", content = @Content(mediaType = "application/json"))
     public ResponseEntity<String> signupMember(@Valid @RequestBody MemberPostDto memberPostDto){
         memberService.createMember(mapper.postDtoToEntity(memberPostDto));
-        return new ResponseEntity<>("정상적으로 가입되었습니다.",HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body("정상적으로 가입되었습니다.");
+
     }
 
     @GetMapping("/logout")
@@ -62,17 +64,19 @@ public class MemberController {
     public ResponseEntity<String> logout(){
         // 로그아웃 로직 수행
         // Redis에서 사용자 정보 및 토큰 정보 삭제
-        return new ResponseEntity<>("로그아웃 되었습니다.", HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body("로그아웃 되었습니다.");
     } 
 
 
     @PatchMapping("/update")
     @Operation(summary ="Update Member", description = "회원수정 API")
     @ApiResponse(responseCode = "200", description = "회원 정보가 정상적으로 수정되었습니다.", content = @Content(mediaType = "application/json"))
-    public ResponseEntity<Void> memberUpdate(@Valid @RequestBody MemberPatchDto memberPatchDto, Authentication authentication){
+    public ResponseEntity<String> memberUpdate(@Valid @RequestBody MemberPatchDto memberPatchDto, Authentication authentication){
         Long memberId = (Long) authentication.getCredentials();
         memberService.updateMember(mapper.patchDtoToEntity(memberPatchDto, memberId));
-        return new ResponseEntity<>(HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body("회원 정보가 정상적으로 수정되었습니다.");
     }
 
 
@@ -83,7 +87,8 @@ public class MemberController {
     public ResponseEntity<MemberResponseDto> getMember(Authentication authentication){
         Long memberId = (Long) authentication.getCredentials();
         log.info("지금 회원 id: {}", memberId);
-        return new ResponseEntity<>(memberService.findMyInfo(memberId), HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(memberService.findMyInfo(memberId));
     }
 
 
@@ -96,6 +101,7 @@ public class MemberController {
     public ResponseEntity<String> memberDelete(Authentication authentication){
         Long memberId = (Long) authentication.getCredentials();
         memberService.deleteMember(memberId);
-        return new ResponseEntity<>("회원 탈퇴가 이뤄졌습니다.", HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body("회원이 정상적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/example/magnet/mentee/controller/MenteeController.java
+++ b/src/main/java/com/example/magnet/mentee/controller/MenteeController.java
@@ -40,7 +40,8 @@ public class MenteeController {
                 .map(GrantedAuthority::getAuthority)
                 .toList();
         menteeService.paidMentee(menteePostDto, memberId, roles);
-        return new ResponseEntity<>("멘토링 신청이 완료되었습니다.", HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body("멘토링 신청이 완료되었습니다.");
     }
 
 //    @PostMapping("/create")
@@ -55,7 +56,8 @@ public class MenteeController {
     @Operation(summary ="Get Mentee", description = "멘티 정보 단건조회 API")
     @ApiResponse(responseCode = "200", description = "멘티 정보 단건조회 성공.", content = @Content(mediaType = "application/json"))
     public ResponseEntity<MenteeResponseDto> menteeInfo(@Valid @PathVariable("mentee-id") Long menteeId, Authentication authentication){
-        return new ResponseEntity<>(menteeService.getInfo(menteeId, (Long)authentication.getCredentials()),HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(menteeService.getInfo(menteeId, (Long)authentication.getCredentials()));
     }
 
     // 회원조회 - 멘토 - 멘토링 - 멘티 리스트 조회
@@ -64,6 +66,7 @@ public class MenteeController {
     @ApiResponse(responseCode = "200", description = "멘티 정보 리스트 조회 성공", content = @Content(mediaType = "application/json"))
     public ResponseEntity<List<AppliedMenteesDto>> mentees(@Valid @PathVariable("mentoring-id") Long mentoringId){
         log.info("mentee list controller 진입");
-        return new ResponseEntity<>(menteeService.getAppliedMentees(mentoringId), HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(menteeService.getAppliedMentees(mentoringId));
     }
 }

--- a/src/main/java/com/example/magnet/mentor/controller/MentorController.java
+++ b/src/main/java/com/example/magnet/mentor/controller/MentorController.java
@@ -49,16 +49,9 @@ public class MentorController {
                 .map(GrantedAuthority::getAuthority)
                 .toList();
 
-        // 멘티 권한이 있다면 멘토로 등록할 수 없다.
-//        if(roles.contains("MENTEE")){
-//            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-//                    .body(new BusinessLogicException(ExceptionCode.MENTEE_CANT_REGISTER_MENTOR));
-//        }else{
-//            mentorService.createMentor(roles, memberId, mentorPostDto);
-//        }
         mentorService.createMentor(roles, memberId, mentorPostDto);
-        return new ResponseEntity<>("멘토 등록이 완료되었습니다.", HttpStatus.CREATED);
-
+        return ResponseEntity.status(201)
+                .body("멘토 등록이 완료되었습니다.");
     }
 
     @GetMapping("/get")
@@ -66,7 +59,8 @@ public class MentorController {
     @ApiResponse(responseCode = "200", description = "멘토 단건조회 성공.", content = @Content(mediaType = "application/json"))
     public ResponseEntity<MentorResponseDto> getMentor(Authentication authentication){
         Long memberId = (Long) authentication.getCredentials();
-        return new ResponseEntity<>(mentorService.getMentor(memberId), HttpStatus.FOUND);
+        return ResponseEntity.ok()
+                .body(mentorService.getMentor(memberId));
     }
 
 
@@ -75,7 +69,8 @@ public class MentorController {
     @ApiResponse(responseCode = "200", description = "멘토 리스트 조회 성공", content = @Content(mediaType = "application/json"))
     public ResponseEntity<Page<MentorSearchResponseDtoV2>> getMentorList(@RequestParam("offset") int offset,
                                                                          @RequestParam("size") int size){ // pageableDefault 적용 ?
-        return new ResponseEntity<>(mentorService.search(offset, size), HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(mentorService.search(offset, size));
     }
 
     @DeleteMapping("/remove")
@@ -88,9 +83,10 @@ public class MentorController {
                 .toList();
         if(roles.contains("MENTOR")||roles.contains("ADMIN")){
             mentorService.remove(memberId);
-            return new ResponseEntity<>("등록한 멘토정보를 삭제했습니다.", HttpStatus.OK);
+            return ResponseEntity.ok().body("등록한 멘토정보를 삭제했습니다.");
         }else{
-            return new ResponseEntity<>(ResponseEntity.badRequest(),HttpStatus.UNAUTHORIZED);
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ResponseEntity.badRequest());
         }
 
     }

--- a/src/main/java/com/example/magnet/mentoring/controller/MentoringController.java
+++ b/src/main/java/com/example/magnet/mentoring/controller/MentoringController.java
@@ -56,7 +56,8 @@ public class MentoringController {
         }
 
         mentoringService.register(memberId, mentoringPostDto);
-        return new ResponseEntity<>("멘토링이 개설되었습니다.", HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body("멘토링이 개설되었습니다.");
 
     }
 
@@ -64,7 +65,8 @@ public class MentoringController {
     @Operation(summary ="Get Mentoring", description = "멘토링 단건 조회 API")
     @ApiResponse(responseCode = "200", description = "멘토링 단건조회 성공.", content = @Content(mediaType = "application/json"))
     public ResponseEntity<MentoringResponseDto> getMentoring(@Valid @PathVariable("mentoring-id") Long mentoringId){
-        return new ResponseEntity<>(mentoringService.mentoringInfo(mentoringId), HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(mentoringService.mentoringInfo(mentoringId));
     }
 
 
@@ -73,7 +75,8 @@ public class MentoringController {
     @Operation(summary ="Get Mentorings", description = "멘토링 리스트 조회 API")
     @ApiResponse(responseCode = "200", description = "멘토링 리스트 조회 성공.", content = @Content(mediaType = "application/json"))
     public ResponseEntity<Page<mentoringListPagingDto>> getMentoringList(Pageable pageable){
-        return new ResponseEntity<>(mentoringService.mentoringInfoList(pageable.getPageNumber(), pageable.getPageSize()), HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(mentoringService.mentoringInfoList(pageable.getPageNumber(), pageable.getPageSize()));
     }
 
 
@@ -90,6 +93,7 @@ public class MentoringController {
         // 현재 memberid와 mentoring id를 service로 전달
         Long memberId = (Long) authentication.getCredentials();
         mentoringService.remove(memberId,mentoringId);
-        return new ResponseEntity<>("멘토링이 삭제되었습니다.", HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body("멘토링이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/example/magnet/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/magnet/payment/controller/PaymentController.java
@@ -23,6 +23,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Collections;
+
 import static com.example.magnet.payment.mapper.PaymentMapper.chargingHistoryToChargingHistoryResponses;
 
 /**
@@ -49,7 +51,8 @@ public class PaymentController {
         PaymentResponseDto result = paymentResponseDto.toBuilder()
                 .successUrl(paymentReqDto.getYourSuccessUrl() == null ? tossPaymentConfig.getSuccessUrl() : paymentReqDto.getYourSuccessUrl())
                 .failUrl(paymentReqDto.getYourFailUrl() == null ? tossPaymentConfig.getFailUrl() : paymentReqDto.getYourFailUrl()).build();
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(result);
     }
 
 
@@ -62,7 +65,8 @@ public class PaymentController {
     public ResponseEntity<PaymentSuccessDto> tossPaymentSuccess(@RequestParam String paymentKey,
                                                                 @RequestParam String orderId,
                                                                 @RequestParam Long amount){
-        return new ResponseEntity<>(paymentService.tossPaymentSuccess(paymentKey, orderId, amount), HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(paymentService.tossPaymentSuccess(paymentKey, orderId, amount));
     }
 
     /**
@@ -78,7 +82,8 @@ public class PaymentController {
                 .errorMessage(message)
                 .orderId(orderId)
                 .build();
-        return new ResponseEntity<>(result, HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(result);
     }
 
     /**
@@ -95,18 +100,23 @@ public class PaymentController {
             @RequestParam String paymentKey,
             @RequestParam String cancelReason
     ){
-        return new ResponseEntity<>(paymentService.cancelPaymentPoint(authentication.getName(), paymentKey, cancelReason), HttpStatus.OK);
+        return ResponseEntity.ok()
+                .body(paymentService.cancelPaymentPoint(authentication.getName(), paymentKey, cancelReason));
     }
 
     @GetMapping("/history")
-    @Operation(summary ="Get ChargingHistory", description = "결제 충전내역 조회 API")
-    @ApiResponse(responseCode = "200", description = "결제 충전내역을 조회합니다.", content = @Content(mediaType = "application/json"))
-    public ResponseEntity getChargingHistory(Authentication authentication,
+    @Operation(summary ="Get ChargingHistory", description = "결제 조회 API")
+    @ApiResponse(responseCode = "200", description = "결제 내역을 조회합니다.", content = @Content(mediaType = "application/json"))
+    public ResponseEntity<?> getChargingHistory(Authentication authentication,
                                              Pageable pageable) {
         Slice<Payment> chargingHistories = paymentService.findAllChargingHistories(authentication.getName(), pageable);
         SliceInfo sliceInfo = new SliceInfo(pageable, chargingHistories.getNumberOfElements(), chargingHistories.hasNext());
-        return new ResponseEntity<>(
-                new SliceResponseDto<>(chargingHistoryToChargingHistoryResponses(chargingHistories.getContent()), sliceInfo), HttpStatus.OK);
+
+        return ResponseEntity.ok()
+                .body(SliceResponseDto.builder()
+                        .data(Collections.singletonList(chargingHistoryToChargingHistoryResponses(chargingHistories.getContent())))
+                        .sliceInfo(sliceInfo)
+                        .build());
     }
 
 }

--- a/src/main/java/com/example/magnet/payment/mapper/PaymentMapper.java
+++ b/src/main/java/com/example/magnet/payment/mapper/PaymentMapper.java
@@ -1,14 +1,11 @@
 package com.example.magnet.payment.mapper;
 
 import com.example.magnet.payment.dto.ChargingHistoryDto;
-import com.example.magnet.payment.dto.PaymentResponseDto;
 import com.example.magnet.payment.dto.PaymentResponseDtoV2;
 import com.example.magnet.payment.entity.Payment;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class PaymentMapper {


### PR DESCRIPTION
- ResponseEntity 생성자 패턴으로 반환하던 기존 코드를 빌더패턴으로 리팩토링했습니다. 
- 기존보다 더 명확하게 변경사항을 인지할 수 있고, 코드 유지보수성이 증가했습니다. 
- 생성자 패턴 사용 시 http 상태코드를 하드코딩하게 되는데, 이때 잘못된 값은 컴파일 타임이 아닌 런타임에 확인하게 됩니다. 이 문제를 빌더패턴을 적용해 해결했습니다. 