### PR TITLE
[refactor]멘토링 리스트 조회 캐싱 적용

### DIFF
--- a/src/main/java/com/example/magnet/global/config/RedisConfig.java
+++ b/src/main/java/com/example/magnet/global/config/RedisConfig.java
@@ -1,0 +1,72 @@
+package com.example.magnet.global.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Value("${spring.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() { // Redis 연결 설정, Lettuce는 레디스 클라이언트 라이브러리
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration();
+        redisConfig.setHostName(host);
+        redisConfig.setPort(port);
+        redisConfig.setPassword(RedisPassword.of(password));
+
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        // 키와 값의 직렬화 방법 설정
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager(){
+        // 캐시 설정 구성 - 키: 문자열 / 값: json
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(30L)); // 캐시 유효기간 설정
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory())
+                .cacheDefaults(redisCacheConfiguration).build();
+    }
+
+
+}

--- a/src/main/java/com/example/magnet/mentoring/service/MentoringService.java
+++ b/src/main/java/com/example/magnet/mentoring/service/MentoringService.java
@@ -13,6 +13,7 @@ import com.example.magnet.mentoring.entity.Mentoring;
 import com.example.magnet.mentoring.repository.MentoringRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -69,6 +70,7 @@ public class MentoringService {
     }
 
     @Transactional(readOnly = true)
+    @Cacheable(value = "mentoringCache", cacheManager = "redisCacheManager") // value: 반환 데이터가 저장되는 캐시의 이름 정의
     public Page<mentoringListPagingDto> mentoringInfoList(int offset, int size) {
         Pageable pageable = PageRequest.of(offset, size);
         return mentoringRepository.mentoringList(pageable);


### PR DESCRIPTION
- @Cacheable 어노테이션을 적용. 페이징 처리를 캐시에서 조회하도록 수정했습니다. 
- 멘토링 생성 시 데이터 정합성을 위해 기존 캐시를 삭제하도록 수정중입니다. 